### PR TITLE
Fix incorrect argument name in the dev script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "--disable-warning=ExperimentalWarning"
   ],
   "scripts": {
-    "dev": "npx tsx run.ts --mode development --port 3000",
+    "dev": "npx tsx run.ts --mode development --web-port 3000",
     "dev-bun": "nodemon --exec 'bun run.ts' --watch server --watch shared --watch *.ts --ext ts,tsx,js,mjs,json",
     "build": "vite build",
     "prod": "vite build && bun run.ts --mode=production",


### PR DESCRIPTION
According to the implementation in  https://github.com/mayfer/dbpill/blob/8d37f8f36d0111692de355ee12cd9406cd8eb2f2/server/args.ts#L100  the correct argument name should be --web-port rather than --port. This patch updates the script to use the correct parameter.
